### PR TITLE
RPMSG fixes

### DIFF
--- a/BeagleBone/TachController/pru/main.c
+++ b/BeagleBone/TachController/pru/main.c
@@ -32,15 +32,17 @@ static const uint32_t k_host_interupt = 0x1 << 30;
 // PRU0 uses system event 16 (To ARM) and 17 (From ARM)
 // PRU1 uses system event 18 (To ARM) and 19 (From ARM)
 
-static const uint32_t k_pru_to_host_event = 16;
-static const uint32_t k_pru_from_host_event = 17;
+static const uint32_t k_pru_to_host_event = 18;
+static const uint32_t k_pru_from_host_event = 19;
 
 static const uint32_t k_heartbeat_dt = 500000;
 
 // file scope statics
 
 static struct pru_rpmsg_transport s_transport;
-static int8_t s_payload[RPMSG_BUF_SIZE];
+// In example code this RPMSG_MESSAGE_SIZE, which is defined in
+// pru-icss-5.60/include/pru_rpmsg.h
+static int8_t s_payload[496];
 
 
 static uint32_t s_heartbeat_start_time;

--- a/BeagleBone/TachController/pru/resource_table_1.h
+++ b/BeagleBone/TachController/pru/resource_table_1.h
@@ -38,6 +38,10 @@
 #include <rsc_types.h>
 #include "pru_virtio_ids.h"
 
+// In the example code this is define in
+// pru-icss-5.6.0/include/rsc_types.h
+#define FW_RSC_ADDR_ANY           (~0)
+
 /*
  * Sizes of the virtqueues (expressed in number of buffers supported,
  * and must be power of 2)
@@ -102,14 +106,14 @@ struct my_resource_table resourceTable = {
 	},
 	/* the two vrings */
 	{
-		0,                      //da, will be populated by host, can't pass it in
+		FW_RSC_ADDR_ANY,        //da, will be populated by host, can't pass it in
 		16,                     //align (bytes),
 		PRU_RPMSG_VQ0_SIZE,     //num of descriptors
 		0,                      //notifyid, will be populated, can't pass right now
 		0                       //reserved
 	},
 	{
-		0,                      //da, will be populated by host, can't pass it in
+		FW_RSC_ADDR_ANY,        //da, will be populated by host, can't pass it in
 		16,                     //align (bytes),
 		PRU_RPMSG_VQ1_SIZE,     //num of descriptors
 		0,                      //notifyid, will be populated, can't pass right now
@@ -117,7 +121,7 @@ struct my_resource_table resourceTable = {
 	},
 
 	{
-		TYPE_CUSTOM, TYPE_PRU_INTS,
+		TYPE_POSTLOAD_VENDOR, PRU_INTS_VER0 | TYPE_PRU_INTS,
 		sizeof(struct fw_rsc_custom_ints),
 		{ /* PRU_INTS version */
 			0x0000,


### PR DESCRIPTION
The important fix was the interrupt numbers in main.c around line 35,
see the comment immediately above.

Changing FW_RSC_ADDR_ANY from 0 to (~0) was probably important, but I
found that before I fixed the interrupt, so I'm not sure how big a deal
it was.

The other changes (message size and the constants at the top of the
resource deinition) are things I noticed were different in the example
code, but I don't know how important they are.